### PR TITLE
Update app.rb with cluster region

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,8 @@ require 'pusher'
 pusher = Pusher::Client.new({
 	app_id: ENV["PUSHER_APP_ID"],
 	key: ENV["PUSHER_APP_KEY"],
-	secret: ENV["PUSHER_APP_SECRET"]
+	secret: ENV["PUSHER_APP_SECRET"],
+	cluster: ENV["PUSHER_CLUSTER"]
 })
 
 get '/' do


### PR DESCRIPTION
Pusher requires the cluster to be set to the appropriate region, in addition to the API keys. Without this running the app throws the below error:

Bad request: Unknown auth_key (Pusher::Error)